### PR TITLE
extraneous newline(s) at end of repose --elephant output(s)

### DIFF
--- a/repose.c
+++ b/repose.c
@@ -575,10 +575,10 @@ static void __attribute__((__noreturn__)) elephant(void)
         "ICAgJ1wgICAgICAgICAgICAgICAgICAgICAgIC8KICAgICAgICAgICBfLyBcLyAgICApLiAgICAg"
         "ICAgKSAgICAoCiAgICAgICAgICAvIyAgLiEgICAgfCAgICAgICAgL1wgICAgLwogICAgICAgICAg"
         "XCAgQy8vICMgIC8nLS0tLS0nJy8gIyAgLwogICAgICAgLiAgICdDLyB8ICAgIHwgICAgfCAgIHwg"
-        "ICAgfG1yZiAgLAogICAgICAgXCksIC4uIC4nT09PLScuIC4uJ09PTydPT08tJy4gLi5cKCwK",
+        "ICAgfG1yZiAgLAogICAgICAgXCksIC4uIC4nT09PLScuIC4uJ09PTydPT08tJy4gLi5cKCw=",
         "ICAgIF8gICAgXwogICAvIFxfXy8gXF9fX19fCiAgLyAgLyAgXCAgXCAgICBgXAogICkgIFwnJy8g"
         "ICggICAgIHxcCiAgYFxfXykvX18vJ19cICAvIGAKICAgICAvL198X3x+fF98X3wKICAgICBeIiIn"
-        "IicgIiInIicK"
+        "IicgIiInIic="
     };
 
     srand(time(NULL));


### PR DESCRIPTION
To maintain backward-compatibility with repo-elephant, repose must stop putting an extraneous newline at the end of repose-elephant(s):

``` diff
diff -u <(repo-elephant) <(repose --elephant) 
--- /proc/self/fd/11    2013-06-09 17:06:39.800401213 -0500
+++ /proc/self/fd/12    2013-06-09 17:06:39.800401213 -0500
@@ -5,3 +5,4 @@
   `\__)/__/'_\  / `
      //_|_|~|_|_|
      ^""'"' ""'"'
+
diff -u <(repo-elephant) <(repose --elephant)
--- /proc/self/fd/11    2013-06-09 17:19:10.030396722 -0500
+++ /proc/self/fd/12    2013-06-09 17:19:10.030396722 -0500
@@ -13,3 +13,4 @@
           \  C// #  /'-----''/ #  /
        .   'C/ |    |    |   |    |mrf  ,
        \), .. .'OOO-'. ..'OOO'OOO-'. ..\(,
+
```
