### PR TITLE
Require only one action argument

### DIFF
--- a/repose.c
+++ b/repose.c
@@ -680,15 +680,23 @@ void parse_repose_args(int *argc, char **argv[])
             printf("%s %s\n", program_invocation_short_name, REPOSE_VERSION);
             exit(EXIT_SUCCESS);
         case 'V':
+            if(cfg.action != INVALID_ACTION)
+                errx(EXIT_FAILURE, "only one operation may be used at a time");
             cfg.action = ACTION_VERIFY;
             break;
         case 'U':
+            if(cfg.action != INVALID_ACTION)
+                errx(EXIT_FAILURE, "only one operation may be used at a time");
             cfg.action = ACTION_UPDATE;
             break;
         case 'R':
+            if(cfg.action != INVALID_ACTION)
+                errx(EXIT_FAILURE, "only one operation may be used at a time");
             cfg.action = ACTION_REMOVE;
             break;
         case 'Q':
+            if(cfg.action != INVALID_ACTION)
+                errx(EXIT_FAILURE, "only one operation may be used at a time");
             cfg.action = ACTION_QUERY;
             break;
         case 'i':


### PR DESCRIPTION
Adds a check to the option parsing to make sure we don't get conflicting
action arguments.
