### PR TITLE
Add PREFIX variable to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CFLAGS := -std=c99 \
 	${CFLAGS}
 
 LDLIBS = -larchive -lalpm -lgpgme -lcrypto -lssl
+PREFIX = /usr
 
 all: repose
 repose: repose.o database.o buffer.o \
@@ -14,8 +15,8 @@ repose: repose.o database.o buffer.o \
 	alpm/pkghash.o alpm/signing.o alpm/base64.o alpm/util.o
 
 install: repose
-	install -Dm755 repose ${DESTDIR}/usr/bin/repose
-	install -Dm644 _repose ${DESTDIR}/usr/share/zsh/site-functions/_repose
+	install -Dm755 repose ${DESTDIR}${PREFIX}/bin/repose
+	install -Dm644 _repose ${DESTDIR}${PREFIX}/share/zsh/site-functions/_repose
 	# install -Dm644 repose.1 $(DESTDIR)/usr/share/man/man1/repose.1
 
 clean:


### PR DESCRIPTION
This allows users to install repose to an alternate location, such as
/usr/local or just plain /.
