### PR TITLE
repose: Set locale according to envvars

### DIFF
--- a/src/repose.c
+++ b/src/repose.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <linux/btrfs.h>
+#include <locale.h>
 
 #include "database.h"
 #include "filecache.h"
@@ -377,6 +378,8 @@ int main(int argc, char *argv[])
 {
     const char *rootname;
     bool files = false, rebuild = false, drop = false, list = false;
+
+    setlocale(LC_ALL, "");
 
     static const struct option opts[] = {
         { "help",     no_argument,       0, 'h' },


### PR DESCRIPTION
Running setlocale with an empty string sets the locale according to the
appropriate environment variables.

Without this the locale won't be set correctly, causing libarchive to
incorrectly set hdrcharset to BINARY when filenames contain Unicode
characters due to the default locale being C.

Fixes #34.

Signed-off-by: Johannes Löthberg <johannes@kyriasis.com>