### PR TITLE
Fix parser when contents contains '%'.

### DIFF
--- a/src/desc.rl
+++ b/src/desc.rl
@@ -49,7 +49,7 @@
            | '%DELTAS%'       %{ parser->entry = PKG_FILES; };
 
       section = header '\n';
-      contents = [^%\n]+ @store %emit '\n';
+      contents = [^\n]+ @store %emit '\n';
 
       main := ( section contents* '\n' | '\n' )*;
 }%%


### PR DESCRIPTION
Parser fail if file database contains a file with '%' in the path.

This fix should work fine if db entry are always separated by a blank line.