### PR TITLE
Update database entries to match repo-add behavior

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -301,10 +301,7 @@ static void compile_desc_entry(struct database_writer *db, struct pkg *pkg)
     write_entry(&db->buf, "BUILDDATE", pkg->builddate);
     write_entry(&db->buf, "PACKAGER",  pkg->packager);
     write_entry(&db->buf, "REPLACES",  pkg->replaces);
-}
 
-static void compile_depends_entry(struct database_writer *db, struct pkg *pkg)
-{
     write_entry(&db->buf, "DEPENDS",      pkg->depends);
     write_entry(&db->buf, "CONFLICTS",    pkg->conflicts);
     write_entry(&db->buf, "PROVIDES",     pkg->provides);
@@ -337,10 +334,6 @@ static void compile_database_entry(struct database_writer *db, struct pkg *pkg)
     if (db->contents & DB_DESC) {
         compile_desc_entry(db, pkg);
         commit_entry(db, "desc", folder);
-    }
-    if (db->contents & DB_DEPENDS) {
-        compile_depends_entry(db, pkg);
-        commit_entry(db, "depends", folder);
     }
     if (db->contents & DB_FILES) {
         compile_files_entry(db, pkg);

--- a/src/database.h
+++ b/src/database.h
@@ -6,7 +6,7 @@ struct repo;
 
 enum contents {
     DB_DESC    = 1,
-    DB_DEPENDS = 1 << 2,
+    DB_DEPENDS __attribute__ ((deprecated ("Dependency information now included in DB_DESC"))) = 1 << 2,
     DB_FILES   = 1 << 3,
     DB_DELTAS  = 1 << 4
 };

--- a/src/repose.c
+++ b/src/repose.c
@@ -553,10 +553,10 @@ int main(int argc, char *argv[])
     if (!repo.dirty) {
         trace("repo does not need updating\n");
     } else {
-        write_database(&repo, repo.dbname, DB_DESC | DB_DEPENDS);
+        write_database(&repo, repo.dbname, DB_DESC);
 
         if (repo.filesname) {
-            write_database(&repo, repo.filesname, DB_FILES);
+            write_database(&repo, repo.filesname, DB_DESC | DB_FILES);
         }
 
         link_db(&repo);

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -39,10 +39,8 @@ x86_64
 
 %PACKAGER%
 Simon Gomizelj <simongmzlj@gmail.com>
-'''
 
-
-REPOSE_DEPENDS = '''%DEPENDS%
+%DEPENDS%
 pacman
 libarchive
 gnupg
@@ -80,7 +78,7 @@ def pkg():
 
 def test_parse_desc(pkg, parser):
     parser.feed(pkg, REPOSE_DESC)
-    assert parser.entry == lib.PKG_PACKAGER
+    assert parser.entry == lib.PKG_MAKEDEPENDS
 
     assert pkg.base is None
     assert pkg.base64sig is None
@@ -94,12 +92,6 @@ def test_parse_desc(pkg, parser):
     assert pkg.builddate == "Nov 28, 2015, 06:04:29"
     assert pkg.packager == 'Simon Gomizelj <simongmzlj@gmail.com>'
     assert pkg.licenses == ['GPL']
-
-
-def test_parse_depends(pkg, parser):
-    parser.feed(pkg, REPOSE_DEPENDS)
-    assert parser.entry == lib.PKG_MAKEDEPENDS
-
     assert pkg.depends == ['pacman', 'libarchive', 'gnupg']
     assert pkg.conflicts == ['repose']
     assert pkg.provides == ['repose']


### PR DESCRIPTION
Change database generation to match repo-add behavior more closely:
 - Write depends information into desc entries
 - No longer generate depends entries
 - Add desc entries to the files database